### PR TITLE
Fix loading `app/etc/n98-magerun.yaml`

### DIFF
--- a/src/N98/Magento/Application/ConfigurationLoader.php
+++ b/src/N98/Magento/Application/ConfigurationLoader.php
@@ -316,7 +316,7 @@ class ConfigurationLoader
      */
     public function loadProjectConfig($magentoRootFolder, $magerunStopFileFolder, array $config)
     {
-        if (empty($this->projectConfig)) {
+        if (!empty($this->projectConfig)) {
             return ArrayFunctions::mergeArrays($config, $this->projectConfig);
         }
 


### PR DESCRIPTION
ConfigurationLoader.php::loadProjectConfig..

After recent refactoring, `$projectConfig` changed from `null` instanciated to `[]`.
The corresponding check in `loadProjectConfig` changed to a `!== null` to `empty()`.

This is opposite of the previous functionality and prevented the projectConfig from being loaded, (because `$projectConfig` always starts off empty).

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: (50 characters or less)

Ref: https://github.com/netz98/n98-magerun2/commit/e80ab373b7c67c14b238cd194a5cd7c5a95bfe4d#r36645773